### PR TITLE
Make it easier to develop widgets with external JS includes - Fixes #4

### DIFF
--- a/core-component-page.html
+++ b/core-component-page.html
@@ -40,7 +40,7 @@ Note: `<core-component-page>` sets the page title automatically.
 
 -->
 
-<polymer-element name="core-component-page" attributes="moduleName sources" layout vertical>
+<polymer-element name="core-component-page" attributes="js merge moduleName sources" layout vertical>
 
   <template>
 
@@ -51,7 +51,7 @@ Note: `<core-component-page>` sets the page title automatically.
       <a class="choiceC" target="_blank" href="../{{moduleName}}/demo.html">demo</a>
     </core-toolbar>
 
-    <core-doc-viewer flex sources="{{sources}}"></core-doc-viewer>
+    <core-doc-viewer flex merge?="{{merge}}" sources="{{sources}}"></core-doc-viewer>
 
   </template>
 
@@ -59,6 +59,8 @@ Note: `<core-component-page>` sets the page title automatically.
 
     Polymer({
 
+      js: false,
+      merge: false,
       moduleName: '',
       // TODO(sjmiles): needed this to force Object type for deserialization
       sources: [],
@@ -68,10 +70,24 @@ Note: `<core-component-page>` sets the page title automatically.
       },
 
       moduleNameChanged: function() {
-        document.title = this.moduleName;
+        var
+          moduleName = document.title = this.moduleName,
+          sources = this.sources,
+          regex = /\.html?$/
+        ;
 
-        if (!this.sources.length && this.moduleName) {
-          this.sources.push(this.moduleName + '.html');
+        if (!sources.length && moduleName) {
+          sources.push(moduleName + '.html');
+        }
+
+        if (this.js) {
+          sources.forEach(function(source) {
+            var js;
+
+            if (regex.test(source) && sources.indexOf(js = source.replace(regex, '.js')) == -1) {
+              sources.push(js);
+            }
+          });
         }
       },
 

--- a/core-component-page.html
+++ b/core-component-page.html
@@ -51,7 +51,7 @@ Note: `<core-component-page>` sets the page title automatically.
       <a class="choiceC" target="_blank" href="../{{moduleName}}/demo.html">demo</a>
     </core-toolbar>
 
-    <core-doc-viewer flex url="{{url}}" sources="{{sources}}"></core-doc-viewer>
+    <core-doc-viewer flex sources="{{sources}}"></core-doc-viewer>
 
   </template>
 
@@ -69,7 +69,10 @@ Note: `<core-component-page>` sets the page title automatically.
 
       moduleNameChanged: function() {
         document.title = this.moduleName;
-        this.url = !this.sources.length && this.moduleName ? this.moduleName + '.html' : '';
+
+        if (!this.sources.length && this.moduleName) {
+          this.sources.push(this.moduleName + '.html');
+        }
       },
 
       findModuleName: function() {


### PR DESCRIPTION
This is 2 related changes:
- passes `merge` flag to `core-doc-viewer` - This doesn't do anything on its own. It is also waiting on a pull request there (Polymer/core-doc-viewer#52). See the pull request for details.
- Intelligently finds .js files named similarly to .html files

This allows devs to develop elements with external js includes and have them documented easily.

References:

Polymer/core-component-page#7
